### PR TITLE
fix typo on README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ amazing [Dash App](http://kapeli.com/dash/) for Mac
 
 1. Download / Extract Source to directory of your choosing
 2. Place all HTML files into the <strong>files_go_here</strong> dir
-3. Place an Icon (icon.png) into the <strong>icon_goes_here</strong> dir
-4. Now edit the <strong>docset.config.php<strong> file
+3. Place an Icon (icon.png) into the <strong>icon_goes_in_here</strong> dir
+4. Create an empty <strong<output</strong> dir
+5. Now edit the <strong>docset.config.php<strong> file
 
 ```php
 /*DOCSET FILENAME*/
@@ -34,6 +35,3 @@ php create-docset.php
 ```
 
 #####The .docset should now show up in the "output" folder!
-
-
-


### PR DESCRIPTION
Was having some trouble running the script because the folder name mentioned in the README is different than what the app expects. 

Was also getting an error saying that the `output` directory doesn't exist when running the script so I added instructions for that as well.

```
Warning: mkdir(): No such file or directory in ~/projects/Dash-Docset-Creator/create-docset.php on line 8
```
